### PR TITLE
Release 1.0.0.

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Converters
 release:
-  current-version: 1.0.0-SNAPSHOT
-  next-version: 1.0.0-SNAPSHOT
+  current-version: 1.0.0
+  next-version: 1.0.1-SNAPSHOT


### PR DESCRIPTION
This is to release a first version of Converts as a baseline (copied as is from Config) before any considerable changes.